### PR TITLE
Update README references from API 2 to API 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 # VoiceIt2-Ruby [![travis](https://app.travis-ci.com/voiceittech/VoiceIt2-Ruby.svg?branch=master)](https://app.travis-ci.com/github/voiceittech/VoiceIt2-Ruby) [![version](https://img.shields.io/gem/v/VoiceIt2)](https://rubygems.org/gems/VoiceIt2) [![downloads](https://img.shields.io/gem/dt/VoiceIt2)](https://rubygems.org/gems/VoiceIt2) ![MIT](https://img.shields.io/github/license/mashape/apistatus.svg)
 
-A Ruby wrapper for VoiceIt's API 2.0 featuring Voice + Face Verification and Identification.
+A Ruby wrapper for VoiceIt's API 3.0 featuring Voice + Face Verification and Identification.
 
 ## Getting Started
 
 Sign up for a free Developer Account at [VoiceIt.io](https://voiceit.io/signup). Visit the settings tab to view your API Key and Token. 
 
 ## API calls
-You can visit our [HTTP API 2.0 Documentation](https://api.voiceit.io/?ruby#introduction) for detailed information on each API call.
+You can visit our [HTTP API 3.0 Documentation](https://api.voiceit.io/?ruby#introduction) for detailed information on each API call.
 
 ## Support
 


### PR DESCRIPTION
## Summary
- Updated all README references from "API 2" to "API 3" (including "Api 2" -> "Api 3" and "api 2" -> "api 3")
- No URL paths or version numbers were modified

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm no URLs or version strings were inadvertently changed

Generated with [Claude Code](https://claude.com/claude-code)