### PR TITLE
Remove switchSubAccountType (dead endpoint)

### DIFF
--- a/Tests.rb
+++ b/Tests.rb
@@ -102,9 +102,6 @@ class TestVoiceIt2 < Test::Unit::TestCase
     assert_equal(201, ret['status'])
     assert_equal('SUCC', ret['responseCode'])
     unmanagedSubAccountAPIKey = ret['apiKey']
-    ret = JSON.parse(myVoiceIt.switchSubAccountType(ret['apiKey']))
-    assert_equal(200, ret['status'])
-    assert_equal('SUCC', ret['responseCode'])
     ret = JSON.parse(myVoiceIt.regenerateSubAccountAPIToken(managedSubAccountAPIKey))
     assert_equal(200, ret['status'])
     assert_equal('SUCC', ret['responseCode'])

--- a/VoiceIt2.rb
+++ b/VoiceIt2.rb
@@ -106,19 +106,6 @@ class VoiceIt2
       end
   end
 
-  def switchSubAccountType(subAccountAPIKey)
-    return RestClient::Request.new(
-      :method => :post,
-      :url => @base_url + '/subaccount/' + subAccountAPIKey + '/switchType' + @notification_url,
-      :user => @api_key,
-      :password => @api_token,
-      :headers => {
-        platformId: PLATFORM_ID,
-        platformVersion: VERSION
-      }).execute
-    rescue => e
-        e.response
-  end
 
   def createUnmanagedSubAccount(firstName, lastName, email, password, contentLanguage)
     return  RestClient::Request.new(


### PR DESCRIPTION
## Summary
- Removes `switchSubAccountType()` method from `VoiceIt2.rb` — calls non-existent `/subaccount/{key}/switchType` endpoint
- Removes corresponding test assertions

## Test plan
- [ ] Verify no remaining references to `switchType` in codebase
- [ ] Run existing sub-account tests to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)