### PR TITLE
Rebrand VoiceIt2 to VoiceIt3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-VoiceIt2.gemspec
+VoiceIt3.gemspec
 *.wav
 *.mov
 *.mp4

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img src="./ruby.png" width="100%" style="width:100%" />
 
-# VoiceIt3-Ruby [![travis](https://app.travis-ci.com/voiceittech/VoiceIt3-Ruby.svg?branch=master)](https://app.travis-ci.com/github/voiceittech/VoiceIt3-Ruby) [![version](https://img.shields.io/gem/v/VoiceIt2)](https://rubygems.org/gems/VoiceIt2) [![downloads](https://img.shields.io/gem/dt/VoiceIt2)](https://rubygems.org/gems/VoiceIt2) ![MIT](https://img.shields.io/github/license/mashape/apistatus.svg)
+# VoiceIt3-Ruby [![travis](https://app.travis-ci.com/voiceittech/VoiceIt3-Ruby.svg?branch=master)](https://app.travis-ci.com/github/voiceittech/VoiceIt3-Ruby) [![version](https://img.shields.io/gem/v/VoiceIt3)](https://rubygems.org/gems/VoiceIt3) [![downloads](https://img.shields.io/gem/dt/VoiceIt3)](https://rubygems.org/gems/VoiceIt3) ![MIT](https://img.shields.io/github/license/mashape/apistatus.svg)
 
 A Ruby wrapper for VoiceIt's API 3.0 featuring Voice + Face Verification and Identification.
 

--- a/Tests.rb
+++ b/Tests.rb
@@ -1,10 +1,10 @@
-require './VoiceIt2.rb'
+require './VoiceIt3.rb'
 require 'json'
 require "test/unit"
 require 'open-uri'
 require 'net/http'
 
-class TestVoiceIt2 < Test::Unit::TestCase
+class TestVoiceIt3 < Test::Unit::TestCase
 
   def download_file(link, filename)
     File.open(filename, "wb") do |saved_file|
@@ -17,9 +17,9 @@ class TestVoiceIt2 < Test::Unit::TestCase
   def test_notification_url() # test webhook URL's
     viapikey = ENV['VIAPIKEY']
     viapitoken = ENV['VIAPITOKEN']
-    myVoiceIt = VoiceIt2.new(viapikey, viapitoken, 'https://api.voiceit.io')
+    myVoiceIt = VoiceIt3.new(viapikey, viapitoken, 'https://api.voiceit.io')
     if ENV['BOXFUSE_ENV'] == 'voiceittest'
-      File.write(ENV['HOME'] + '/' + 'platformVersion', VoiceIt2::VERSION)
+      File.write(ENV['HOME'] + '/' + 'platformVersion', VoiceIt3::VERSION)
     end
     myVoiceIt.addNotificationUrl('https://voiceit.io')
     assert_equal(myVoiceIt.notification_url, "?notificationURL=https%3A%2F%2Fvoiceit.io")
@@ -30,7 +30,7 @@ class TestVoiceIt2 < Test::Unit::TestCase
   def test_users_groups() # get all users, get all groups, create user, create group, add user to group, remove user from group, delete user delete group
     viapikey = ENV['VIAPIKEY']
     viapitoken = ENV['VIAPITOKEN']
-    myVoiceIt = VoiceIt2.new(viapikey, viapitoken, 'https://api.voiceit.io')
+    myVoiceIt = VoiceIt3.new(viapikey, viapitoken, 'https://api.voiceit.io')
     ret = JSON.parse(myVoiceIt.createUser())
     assert_equal(201, ret['status'])
     assert_equal('SUCC', ret['responseCode'])
@@ -93,7 +93,7 @@ class TestVoiceIt2 < Test::Unit::TestCase
   def test_sub_accounts()
     viapikey = ENV['VIAPIKEY']
     viapitoken = ENV['VIAPITOKEN']
-    myVoiceIt = VoiceIt2.new(viapikey, viapitoken, 'https://api.voiceit.io')
+    myVoiceIt = VoiceIt3.new(viapikey, viapitoken, 'https://api.voiceit.io')
     ret = JSON.parse(myVoiceIt.createManagedSubAccount('Test','Ruby', '', '', ''))
     assert_equal(201, ret['status'])
     assert_equal('SUCC', ret['responseCode'])
@@ -125,7 +125,7 @@ class TestVoiceIt2 < Test::Unit::TestCase
 
     viapikey = ENV['VIAPIKEY']
     viapitoken = ENV['VIAPITOKEN']
-    myVoiceIt = VoiceIt2.new(viapikey, viapitoken, 'https://api.voiceit.io')
+    myVoiceIt = VoiceIt3.new(viapikey, viapitoken, 'https://api.voiceit.io')
     userId1 = JSON.parse(myVoiceIt.createUser())['userId']
     userId2 = JSON.parse(myVoiceIt.createUser())['userId']
     groupId = JSON.parse(myVoiceIt.createGroup('Sample Group Description'))['groupId']
@@ -257,7 +257,7 @@ class TestVoiceIt2 < Test::Unit::TestCase
 
     viapikey = ENV['VIAPIKEY']
     viapitoken = ENV['VIAPITOKEN']
-    myVoiceIt = VoiceIt2.new(viapikey, viapitoken, 'https://api.voiceit.io')
+    myVoiceIt = VoiceIt3.new(viapikey, viapitoken, 'https://api.voiceit.io')
     userId1 = JSON.parse(myVoiceIt.createUser())['userId']
     userId2 = JSON.parse(myVoiceIt.createUser())['userId']
     groupId = JSON.parse(myVoiceIt.createGroup('Sample Group Description'))['groupId']
@@ -388,7 +388,7 @@ class TestVoiceIt2 < Test::Unit::TestCase
 
     viapikey = ENV['VIAPIKEY']
     viapitoken = ENV['VIAPITOKEN']
-    myVoiceIt = VoiceIt2.new(viapikey, viapitoken, 'https://api.voiceit.io')
+    myVoiceIt = VoiceIt3.new(viapikey, viapitoken, 'https://api.voiceit.io')
     userId1 = JSON.parse(myVoiceIt.createUser())['userId']
     userId2 = JSON.parse(myVoiceIt.createUser())['userId']
     groupId = JSON.parse(myVoiceIt.createGroup('Sample Group Description'))['groupId']

--- a/VoiceIt3.rb
+++ b/VoiceIt3.rb
@@ -3,7 +3,7 @@ require 'rest-client'
 require 'cgi'
 
 
-class VoiceIt2
+class VoiceIt3
 
   VERSION = '3.7.1'
   PLATFORM_ID = '35'

--- a/release.sh
+++ b/release.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 commit=$(git log -1 --pretty=%B | head -n 1)
-version=$(echo $(gem search voiceit2 | awk 'NR==1{print $2}' | tr -d "()") | tr "." "\n")
+version=$(echo $(gem search voiceit3 | awk 'NR==1{print $2}' | tr -d "()") | tr "." "\n")
 set -- $version
 major=$1
 minor=$2
@@ -64,20 +64,20 @@ then
   if [[ $wrapperplatformversion = $version ]];
   then
     echo "Gem::Specification.new do |s|
-      s.name        = 'VoiceIt2'
+      s.name        = 'VoiceIt3'
       s.version     = '"$version"'
       s.date        = '"$date"'
       s.summary     = 'VoiceIt Api 3'
       s.description = 'A wrapper for VoiceIt API 3'
       s.authors     = ['StephenAkers']
       s.email       = 'stephen@voiceit.io'
-      s.files       = ['./VoiceIt2.rb']
+      s.files       = ['./VoiceIt3.rb']
       s.homepage    =
         'https://voiceit.io'
       s.license       = 'MIT'
       s.metadata       = {'documentation_uri' => 'https://api.voiceit.io?ruby'}
-    end" > ./VoiceIt2.gemspec
-    gem build VoiceIt2.gemspec
+    end" > ./VoiceIt3.gemspec
+    gem build VoiceIt3.gemspec
     gem push "VoiceIt3-"$version".gem" 1>&2
 
     if [ "$?" != "0" ]
@@ -121,7 +121,7 @@ then
         formattedmessages=$formattedmessages'|'$i
       done
 
-      curl -X POST -H "X-Admin-Password: $EMAILAUTHPASS" --data-urlencode "messages=$formattedmessages" -d "packageManaged=true" --data-urlencode "instructions=gem update VoiceIt2</code></div><br />" "https://api.voiceit.io/platform/35"
+      curl -X POST -H "X-Admin-Password: $EMAILAUTHPASS" --data-urlencode "messages=$formattedmessages" -d "packageManaged=true" --data-urlencode "instructions=gem update VoiceIt3</code></div><br />" "https://api.voiceit.io/platform/35"
     fi
     exit 0
 


### PR DESCRIPTION
## Summary
- Rename all VoiceIt2 references to VoiceIt3 (class names, file names, README)
- Rename `VoiceIt2.rb` → `VoiceIt3.rb`, class `VoiceIt2` → `VoiceIt3`
- Update test file references

🤖 Generated with [Claude Code](https://claude.com/claude-code)